### PR TITLE
Restructure the git repository release discovery

### DIFF
--- a/mak/Makefile.build
+++ b/mak/Makefile.build
@@ -54,12 +54,12 @@ with_expat=
 build-expat:
 else ifeq "$(PREFER_CMAKE)" "1"
 with_expat=--with-expat=$(DESTDIR)
-$(expat_srcdir)/Makefile:  $(SRCDIR)/$(expat_srcdir)/expat/CMakeLists.txt
+$(expat_srcdir)/Makefile:  $(SRCDIR)/$(expat_srcdir)/CMakeLists.txt
 	-mkdir $(expat_srcdir) 2>/dev/null
 	cd $(expat_srcdir) && \
 	  cmake $(CMAKE_DEFAULTS) -D BUILD_tests=OFF -D BUILD_tools=OFF \
 		-D BUILD_shared=OFF -D CMAKE_INSTALL_PREFIX=$(DESTDIR) \
-		$(SRCDIR)/$(expat_srcdir)/expat && \
+		$(SRCDIR)/$(expat_srcdir) && \
 	cd ..
 
 build-expat: $(expat_srcdir)/Makefile
@@ -72,11 +72,11 @@ else
 # DOCBOOK_TO_MAN=`which docbook2x-man db2x_docbook2man 2>/dev/null` 
 # DOCBOOK_TO_MAN="xmlto man --skip-validation"
 with_expat=--with-expat=$(DESTDIR)
-$(expat_srcdir)/Makefile: $(SRCDIR)/$(expat_srcdir)/expat/configure
+$(expat_srcdir)/Makefile: $(SRCDIR)/$(expat_srcdir)/configure
 	-mkdir $(expat_srcdir) 2>/dev/null
 	cd $(expat_srcdir) && \
 	  DOCBOOK_TO_MAN=`which docbook2x-man db2x_docbook2man xmlto | sed "s#xmlto#xmlto man --skip-validation#;1q"` \
-	  $(SRCDIR)/$(expat_srcdir)/expat/configure \
+	  $(SRCDIR)/$(expat_srcdir)/configure \
 		--prefix=$(DESTDIR) && \
 	cd ..
 

--- a/mak/Makefile.build-win
+++ b/mak/Makefile.build-win
@@ -57,12 +57,12 @@ with_expat=
 build-expat:
 !ELSE
 with_expat=--with-expat=$(DESTDIR)
-$(expat_srcdir)/Makefile:  $(SRCDIR)/$(expat_srcdir)/expat/CMakeLists.txt
+$(expat_srcdir)/Makefile:  $(SRCDIR)/$(expat_srcdir)/CMakeLists.txt
 	-mkdir $(expat_srcdir) 2>NUL
 	cd $(expat_srcdir) && \
 	  cmake $(CMAKE_DEFAULTS) -D BUILD_tests=OFF -D BUILD_tools=OFF \
 		-D BUILD_shared=OFF -D CMAKE_INSTALL_PREFIX=$(DESTDIR) \
-		$(SRCDIR)/$(expat_srcdir)/expat && \
+		$(SRCDIR)/$(expat_srcdir) && \
 	cd ..
 
 build-expat: $(expat_srcdir)/Makefile

--- a/mak/Makefile.download
+++ b/mak/Makefile.download
@@ -228,7 +228,7 @@ ifdef libxml2_pkg
 	  cd pkgs && \
 	  wget -nv $(libxml2_srcpath) -O $(libxml2_pkg) && \
 	  cd .. && \
-	  tar -xjf pkgs/$(libxml2_pkg)
+	  tar -xJf pkgs/$(libxml2_pkg)
 else
 	  git clone -q $(libxml2_srcpath) -n -b $(libxml2_ver) $(libxml2_srcdir) && \
 	  cd $(libxml2_srcdir) && git checkout -q $(libxml2_rev) && cd ..

--- a/mak/Makefile.download
+++ b/mak/Makefile.download
@@ -187,8 +187,10 @@ ifdef expat_pkg
 	  cd .. && \
 	  tar -xjf pkgs/$(expat_pkg)
 else
-	  git clone -q $(expat_srcpath).git -n -b $(expat_ver) $(expat_srcdir) && \
-	  cd $(expat_srcdir) && git checkout -q $(expat_rev) && cd ..
+	  git clone -q $(expat_srcpath).git -n -b $(expat_ver) $(expat_srcdir)-tmp && \
+	  cd $(expat_srcdir)-tmp && git checkout -q $(expat_rev) -- expat && cd .. && \
+	  mv $(expat_srcdir)-tmp/expat $(expat_srcdir) && \
+	  rm -rf $(expat_srcdir)-tmp
 endif
 
 

--- a/mak/Makefile.download
+++ b/mak/Makefile.download
@@ -126,7 +126,7 @@ $(nghttp2_srcdir):
 ifdef nghttp2_pkg
 	  if test ! -d pkgs; then mkdir pkgs; fi
 	  cd pkgs && \
-	  wget -nv $(nghttp2_srcpath)/$(nghttp2_pkg) && \
+	  wget -nv $(nghttp2_srcpath) && \
 	  cd .. && \
 	  tar -xjf pkgs/$(nghttp2_pkg)
 else
@@ -183,8 +183,9 @@ ifdef expat_pkg
 	  if test ! -d pkgs; then mkdir pkgs; fi
 	  cd pkgs && \
 	  wget -nv $(expat_srcpath) -O $(expat_pkg) && \
+	  wget -nv $(expat_srcpath).asc -O $(expat_pkg).asc && \
 	  cd .. && \
-	  tar -xzf pkgs/$(expat_pkg)
+	  tar -xjf pkgs/$(expat_pkg)
 else
 	  git clone -q $(expat_srcpath).git -n -b $(expat_ver) $(expat_srcdir) && \
 	  cd $(expat_srcdir) && git checkout -q $(expat_rev) && cd ..
@@ -210,8 +211,9 @@ ifdef jansson_pkg
 	  if test ! -d pkgs; then mkdir pkgs; fi
 	  cd pkgs && \
 	  wget -nv $(jansson_srcpath) -O $(jansson_pkg) && \
+	  wget -nv $(jansson_srcpath).asc -O $(jansson_pkg).asc && \
 	  cd .. && \
-	  tar -xzf pkgs/$(jansson_pkg)
+	  tar -xjf pkgs/$(jansson_pkg)
 else
 	  git clone -q $(jansson_srcpath).git -n -b $(jansson_ver) $(jansson_srcdir) && \
 	  cd $(jansson_srcdir) && git checkout -q $(jansson_rev) && cd ..
@@ -226,7 +228,7 @@ ifdef libxml2_pkg
 	  cd .. && \
 	  tar -xjf pkgs/$(libxml2_pkg)
 else
-	  git clone -q $(libxml2_srcpath).git -n -b $(libxml2_ver) $(libxml2_srcdir) && \
+	  git clone -q $(libxml2_srcpath) -n -b $(libxml2_ver) $(libxml2_srcdir) && \
 	  cd $(libxml2_srcdir) && git checkout -q $(libxml2_rev) && cd ..
 endif
 

--- a/mak/Makefile.gather
+++ b/mak/Makefile.gather
@@ -437,11 +437,12 @@ gather-jansson-master: pre-manifest
 
 
 gather-libxml2-release: pre-manifest
-	libxml2_srcpath=https://gitlab.gnome.org/GNOME/libxml2/- && \
-	libxml2_srcpath=$$libxml2_srcpath/`wget -q -O - $$libxml2_srcpath/tags | sed -n 's#.*<a .* href=".*/GNOME/libxml2/-/\(archive/v[^"/]*/libxml2-v[^"/>]*\.tar\.bz2\)">.*#\1#;t once;$$!b;:once;p;q;'` && \
-	libxml2_pkg=`echo $$libxml2_srcpath | sed "s#.*/\([^/]*\)#\1#;"` && \
-	libxml2_ver=`echo $$libxml2_pkg | sed "s#libxml2-v\(.*\)\.tar\.bz2#\1#;"` && \
-	libxml2_srcdir=`echo $$libxml2_pkg | sed "s#\(.*\)\.tar\.bz2#\1#;"` && \
+	libxml2_srcpath=https://download.gnome.org/sources/libxml2 && \
+	libxml2_srcpath=$$libxml2_srcpath/`wget -q -O - "$$libxml2_srcpath/?C=M&O=D" | sed -n '/<a href="2\.[0-9]/{s#.*<a href="\(2\.[0-9]*\)/.*#\1#p;q}'` && \
+	libxml2_pkg=`wget -q -O - "$$libxml2_srcpath/?C=M&O=D"  | sed -n '/<a href="libxml2-2\.[0-9]*\.[0-9]*\.tar\.xz"/{s#.*<a href="\([^"]*\)".*#\1#p;q}'` && \
+	libxml2_srcdir=`echo $$libxml2_pkg | sed 's#\(libxml2-.*\)\.tar\.xz#\1#;'` && \
+	libxml2_ver=`echo $$libxml2_srcdir | sed 's#libxml2-\(.*\)#\1#;'` && \
+	libxml2_srcpath=$$libxml2_srcpath/$$libxml2_pkg && \
 	echo libxml2_pkg=$$libxml2_pkg >>$(BLD)-manifest-vars && \
 	echo libxml2_srcdir=$$libxml2_srcdir >>$(BLD)-manifest-vars && \
 	echo libxml2_srcpath=$$libxml2_srcpath >>$(BLD)-manifest-vars && \

--- a/mak/Makefile.gather
+++ b/mak/Makefile.gather
@@ -137,9 +137,9 @@ gather-apr-rc: pre-manifest
 	echo apr_ver=$$apr_ver >>$(BLD)-manifest-vars
 
 gather-apr-1xbranch: pre-manifest
-	apr_srcpath=https://svn.apache.org/repos/asf/apr/apr/branches/1.7.x && \
+	apr_srcpath=https://svn.apache.org/repos/asf/apr/apr/branches/1.8.x && \
 	apr_rev=`svn info $$apr_srcpath | sed -n '/Last Changed Rev: \([0-9]\+\)/{s#.*: ##;p}'` && \
-	apr_ver=1.7.x-$$apr_rev && \
+	apr_ver=1.8.x-$$apr_rev && \
 	apr_srcdir=apr-$$apr_ver && \
 	apr_major=`echo $$apr_ver | sed 's#\([0-9]*\)\..*#\1#;'` && \
 	echo apr_major=$$apr_major >>$(BLD)-manifest-vars && \
@@ -448,7 +448,6 @@ gather-libxml2-release: pre-manifest
 	echo libxml2_ver=$$libxml2_ver >>$(BLD)-manifest-vars
 
 gather-libxml2-master: pre-manifest
-	
 	libxml2_srcpath=https://gitlab.gnome.org/GNOME/libxml2.git && \
 	libxml2_ver=master && \
 	if test -d libxml2-git; then ( cd libxml2-git; git fetch --all ); else ( git clone $$libxml2_srcpath --bare libxml2-git ); fi && \

--- a/mak/Makefile.gather
+++ b/mak/Makefile.gather
@@ -137,9 +137,9 @@ gather-apr-rc: pre-manifest
 	echo apr_ver=$$apr_ver >>$(BLD)-manifest-vars
 
 gather-apr-1xbranch: pre-manifest
-	apr_srcpath=https://svn.apache.org/repos/asf/apr/apr/branches/1.8.x && \
+	apr_srcpath=https://svn.apache.org/repos/asf/apr/apr/branches/1.7.x && \
 	apr_rev=`svn info $$apr_srcpath | sed -n '/Last Changed Rev: \([0-9]\+\)/{s#.*: ##;p}'` && \
-	apr_ver=1.8.x-$$apr_rev && \
+	apr_ver=1.7.x-$$apr_rev && \
 	apr_srcdir=apr-$$apr_ver && \
 	apr_major=`echo $$apr_ver | sed 's#\([0-9]*\)\..*#\1#;'` && \
 	echo apr_major=$$apr_major >>$(BLD)-manifest-vars && \
@@ -262,12 +262,12 @@ gather-openssl-master: pre-manifest
 
 
 gather-nghttp2-release: pre-manifest
-	nghttp2_srcpath=https://github.com/nghttp2/nghttp2/releases && \
-	nghttp2_pkg=`wget --max-redirect=0 $$nghttp2_srcpath/latest/ 2>&1 | sed 's#Location: \(.*\)/tag/v\([^/]*\) \[following\]#\1/download/v\2/nghttp2-\2.tar.bz2#p;d;'` && \
-	nghttp2_srcpath=`echo $$nghttp2_pkg | sed 's#/[^/]*$$##;'` && \
-	nghttp2_pkg=`echo $$nghttp2_pkg | sed 's#.*/##;'` && \
-	nghttp2_ver=`echo $$nghttp2_pkg | sed 's#nghttp2-\(.*\)\.tar\.bz2#\1#;'`&& \
+	gitpath=https://github.com/nghttp2/nghttp2 && \
+	gitver=`wget --max-redirect=0 $$gitpath/releases/latest/ 2>&1 | sed 's#Location: .*/tag/\([^/]*\) \[following\]#\1#p;d'` && \
+	nghttp2_ver=`echo $$gitver | sed 's#^v##;'` && \
 	nghttp2_srcdir=nghttp2-$$nghttp2_ver && \
+	nghttp2_pkg=$$nghttp2_srcdir.tar.bz2 && \
+	nghttp2_srcpath=$$gitpath/releases/download/$$gitver/$$nghttp2_pkg && \
 	echo nghttp2_pkg=$$nghttp2_pkg >>$(BLD)-manifest-vars && \
 	echo nghttp2_srcdir=$$nghttp2_srcdir >>$(BLD)-manifest-vars && \
 	echo nghttp2_srcpath=$$nghttp2_srcpath >>$(BLD)-manifest-vars && \
@@ -286,11 +286,12 @@ gather-nghttp2-master: pre-manifest
 
 
 gather-brotli-release: pre-manifest
-	brotli_srcpath=https://github.com/google/brotli/releases && \
-	brotli_ver=`wget --max-redirect=0 $$brotli_srcpath/latest/ 2>&1 | sed 's#Location: .*/tag/v\([^/]*\) \[following\]#\1#p;d;'` && \
-	brotli_srcpath=https://github.com/google/brotli/archive/refs/tags/v$$brotli_ver.tar.gz && \
+	gitpath=https://github.com/google/brotli && \
+	gitver=`wget --max-redirect=0 $$gitpath/releases/latest/ 2>&1 | sed 's#Location: .*/tag/\([^/]*\) \[following\]#\1#p;d;'` && \
+	brotli_ver=`echo $$gitver | sed 's#^v##;'` && \
 	brotli_srcdir=brotli-$$brotli_ver && \
 	brotli_pkg=$$brotli_srcdir.tar.gz && \
+	brotli_srcpath=https://github.com/google/brotli/archive/refs/tags/v$$brotli_ver.tar.gz && \
 	echo brotli_pkg=$$brotli_pkg >>$(BLD)-manifest-vars && \
 	echo brotli_srcdir=$$brotli_srcdir >>$(BLD)-manifest-vars && \
 	echo brotli_srcpath=$$brotli_srcpath >>$(BLD)-manifest-vars && \
@@ -353,12 +354,12 @@ gather-openldap-master: pre-manifest
 
 
 gather-expat-release: pre-manifest
-	expat_srcpath=https://github.com/libexpat/libexpat/releases && \
-	expat_ver=`wget -q -O - $$expat_srcpath | sed -n 's#^.*<a.* href=".*\/archive\/refs\/tags\/R_\(.*\)\.tar\.gz".*$$#\1#;t once;$$!b;:once;p;q;'` && \
-	expat_srcpath=https://github.com/libexpat/libexpat/archive/refs/tags/R_$$expat_ver.tar.gz && \
-	expat_srcdir=libexpat-R_$$expat_ver && \
-	expat_pkg=$$expat_srcdir.tar.gz && \
-	expat_ver=`echo $$expat_ver | sed "s#_#.#g"` && \
+	gitpath=https://github.com/libexpat/libexpat && \
+	gitver=`wget --max-redirect=0 $$gitpath/releases/latest/ 2>&1 | sed 's#Location: .*/tag/\([^/]*\) \[following\]#\1#p;d;'` && \
+	expat_ver=`echo $$gitver | sed 's#^R_##;s#_#.#g;'` && \
+	expat_srcdir=expat-$$expat_ver && \
+	expat_pkg=$$expat_srcdir.tar.bz2 && \
+	expat_srcpath=$$gitpath/releases/download/$$gitver/$$expat_pkg && \
 	echo expat_pkg=$$expat_pkg >>$(BLD)-manifest-vars && \
 	echo expat_srcdir=$$expat_srcdir >>$(BLD)-manifest-vars && \
 	echo expat_srcpath=$$expat_srcpath >>$(BLD)-manifest-vars && \
@@ -388,11 +389,12 @@ gather-pcre-release: pre-manifest
 	echo pcre_ver=$$pcre_ver >>$(BLD)-manifest-vars
 
 gather-pcre2-release: pre-manifest
-	pcre_srcpath=https://github.com/PCRE2Project/pcre2/releases && \
-	pcre_srcpath=$$pcre_srcpath/`wget -q -O - $$pcre_srcpath | sed -n 's#^.*<a.* href=".*/PCRE2Project/pcre2/releases/\(download/pcre2-[^"/]*/pcre2[^"]*\.tar\.bz2\)".*$$#\1#;t once;$$!b;:once;p;q;'` && \
-	pcre_pkg=`echo $$pcre_srcpath | sed "s#.*/\([^/]*\)#\1#;"` && \
-	pcre_ver=`echo $$pcre_pkg | sed "s#pcre2-\(.*\)\.tar\.bz2#\1#;"` && \
-	pcre_srcdir=`echo $$pcre_pkg | sed "s#\(.*\)\.tar\.bz2#\1#;"` && \
+	gitpath=https://github.com/PCRE2Project/pcre2 && \
+	gitver=`wget --max-redirect=0 $$gitpath/releases/latest/ 2>&1 | sed 's#Location: .*/tag/\([^/]*\) \[following\]#\1#p;d;'` && \
+	pcre_ver=`echo $$gitver | sed 's#^pcre2-##;'` && \
+	pcre_srcdir=pcre2-$$pcre_ver && \
+	pcre_pkg=$$pcre_srcdir.tar.bz2 && \
+	pcre_srcpath=$$gitpath/releases/download/$$gitver/$$pcre_pkg && \
 	echo pcre_pkg=$$pcre_pkg >>$(BLD)-manifest-vars && \
 	echo pcre_srcdir=$$pcre_srcdir >>$(BLD)-manifest-vars && \
 	echo pcre_srcpath=$$pcre_srcpath >>$(BLD)-manifest-vars && \
@@ -411,12 +413,12 @@ gather-pcre2-master: pre-manifest
 
 
 gather-jansson-release: pre-manifest
-	jansson_srcpath=https://github.com/akheron/jansson/releases && \
-	jansson_ver=`wget -q -O - $$jansson_srcpath | sed -n 's#^.*<a.* href=".*\/archive\/refs\/tags\/v\(.*\)\.tar\.gz".*$$#\1#;t once;$$!b;:once;p;q;'` && \
-	jansson_srcpath=https://github.com/akheron/jansson/archive/refs/tags/v$$jansson_ver.tar.gz && \
+	gitpath=https://github.com/akheron/jansson && \
+	gitver=`wget --max-redirect=0 $$gitpath/releases/latest/ 2>&1 | sed 's#Location: .*/tag/\([^/]*\) \[following\]#\1#p;d;'` && \
+	jansson_ver=`echo $$gitver | sed "s#^v##;"` && \
 	jansson_srcdir=jansson-$$jansson_ver && \
-	jansson_pkg=$$jansson_srcdir.tar.gz && \
-	jansson_ver=`echo $$jansson_ver | sed "s#_#.#g"` && \
+	jansson_pkg=$$jansson_srcdir.tar.bz2 && \
+	jansson_srcpath=$$gitpath/releases/download/$$gitver/$$jansson_pkg && \
 	echo jansson_pkg=$$jansson_pkg >>$(BLD)-manifest-vars && \
 	echo jansson_srcdir=$$jansson_srcdir >>$(BLD)-manifest-vars && \
 	echo jansson_srcpath=$$jansson_srcpath >>$(BLD)-manifest-vars && \
@@ -446,7 +448,8 @@ gather-libxml2-release: pre-manifest
 	echo libxml2_ver=$$libxml2_ver >>$(BLD)-manifest-vars
 
 gather-libxml2-master: pre-manifest
-	libxml2_srcpath=https://github.com/gnome/libxml2 && \
+	
+	libxml2_srcpath=https://gitlab.gnome.org/GNOME/libxml2.git && \
 	libxml2_ver=master && \
 	if test -d libxml2-git; then ( cd libxml2-git; git fetch --all ); else ( git clone $$libxml2_srcpath --bare libxml2-git ); fi && \
 	libxml2_rev=`cd libxml2-git; git show -b $$libxml2_ver --format="format:%h" --name-only | awk "//{print $$1; exit;}"` && \
@@ -467,6 +470,8 @@ gather-lua-release: pre-manifest
 	echo lua_ver=$$lua_ver >>$(BLD)-manifest-vars
 
 
+# Note that madler/zlib does not have "releases", so will not redirect "latest", always refer to zlib.net
+#
 gather-zlib-release: pre-manifest
 	zlib_srcpath=https://zlib.net && \
 	zlib_pkg=`wget -q -O - $$zlib_srcpath/ | sed -n '/<a href="\(zlib-1\.[0-9.]*\.tar\.gz\).asc"/{s#.*href="\(.*\)\.asc".*#\1#;p;q}'` && \
@@ -479,7 +484,7 @@ gather-zlib-release: pre-manifest
 
 gather-zlib-master: pre-manifest
 	zlib_srcpath=https://github.com/madler/zlib && \
-	zlib_ver=master && \
+	zlib_ver=develop && \
 	if test -d zlib-git; then ( cd zlib-git; git fetch --all ); else ( git clone $$zlib_srcpath --bare zlib-git ); fi && \
 	zlib_rev=`cd zlib-git; git show -b $$zlib_ver --format="format:%h" --name-only | awk "//{print $$1; exit;}"` && \
 	zlib_srcdir=zlib-1.2.x-$$zlib_rev && \

--- a/mak/Makefile.preconfig
+++ b/mak/Makefile.preconfig
@@ -166,14 +166,14 @@ endif
 ifndef expat_srcdir
 preconfig-expat: pre-preconfig
 else
-$(expat_srcdir)/expat/configure: $(expat_srcdir)/expat/configure.ac \
-				 $(expat_srcdir)/expat/Makefile.am
-	-mkdir $(expat_srcdir)/expat/m4 2>/dev/null
-	cd $(expat_srcdir)/expat && \
+$(expat_srcdir)/configure: $(expat_srcdir)/configure.ac \
+				 $(expat_srcdir)/Makefile.am
+	-mkdir $(expat_srcdir)/m4 2>/dev/null
+	cd $(expat_srcdir) && \
 	  ./buildconf.sh && \
-	cd ../..
+	cd ..
 
-preconfig-expat: pre-preconfig $(expat_srcdir)/expat/configure
+preconfig-expat: pre-preconfig $(expat_srcdir)/configure
 endif
 
 


### PR DESCRIPTION
Recovers from recent changes to github's release html pages, where these became nested content, named opaquely. Uses latest which is now consistently used by all but zlib and libxml2 projects to determine the current versions

libxml2 now resolves the release package from download.gnome.org, the new canonical home, and corrected to fetch snapshots from gitlab instead of the out-of-date github mirror. 

zlib snapshots now refer to the `develop` branch for ongoing 1.2.x patches in development.

Resolves: https://github.com/vmware-tanzu/oss-httpd-build/issues/26
Resolves: https://github.com/vmware-tanzu/oss-httpd-build/issues/28

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>