### PR TITLE
Revert workaround for broken curl configure

### DIFF
--- a/mak/Makefile.build
+++ b/mak/Makefile.build
@@ -457,7 +457,7 @@ $(curl_srcdir)/Makefile: build-openssl build-zlib build-brotli build-nghttp2 \
 		 $(with_ssl) \
 		 $(with_zlib) \
 		 $(with_nghttp2) \
-		 --without-brotli \
+		 $(with_brotli) \
 		 --without-gnutls \
 		 --without-polarssl \
 		 --without-mbedtls \


### PR DESCRIPTION
Current curl package now correctly resolves curl and openssl, Issue https://github.com/vmware-tanzu/oss-httpd-build/issues/20 was resolved upstream

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>